### PR TITLE
Content updates by client

### DIFF
--- a/app/en/partials/ENT.html
+++ b/app/en/partials/ENT.html
@@ -1,7 +1,7 @@
 <ol class="breadcrumb">
   <li class="breadcrumb-item"><a ui-sref="app">Home</a></li>
   <li class="breadcrumb-item"><a ui-sref="app.treatments">Treatments</a></li>
-  <li class="breadcrumb-item active">Otolaryngology</li>
+  <li class="breadcrumb-item active">ENT</li>
 </ol>
 <div id="entWrapper" class="treatmentWrapper sliderYp slide-page">
   <div class="row">
@@ -9,7 +9,7 @@
       <div class="jumbotron topJ">
         <div class="container">
           <div class="row">
-            <h1 class="text-center">OTOLARYNGOLOGY</h1>
+            <h1 class="text-center">ENT &ndash; Ears, Nose &amp; Throat</h1>
           </div>
           <div class="row">
             <div class="col-xs-12 col-sm-5">

--- a/app/en/partials/EVLA.html
+++ b/app/en/partials/EVLA.html
@@ -298,7 +298,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTOLARYNGOLOGY</strong><br>Ears, nose, and throat</p>
+        <p><strong>ENT</strong><br>Ears, nose, and throat</p>
         </a>
       </div>
       <div class="row">

--- a/app/en/partials/PLDD.html
+++ b/app/en/partials/PLDD.html
@@ -231,7 +231,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTOLARYNGOLOGY</strong><br>Ears, nose, and throat</p>
+        <p><strong>ENT</strong><br>Ears, nose, and throat</p>
         </a>
       </div>
       <div class="row">

--- a/app/en/partials/contact.html
+++ b/app/en/partials/contact.html
@@ -82,7 +82,7 @@
         <strong>Where to Find Us</strong>
       </p>
       <div class="iframe-container">
-        <iframe frameborder="0" style="border:0; height:200px; width:320px;"  src="https://www.google.com/maps/embed/v1/place?key=AIzaSyCpL_11iHyHj4Bn2vgZERH8qor6VBmgT6s&q=Av.+Joao+de+Cabral+de+Melo+Neto,+850+-+Barra+da+Tijuca,+Rio+de+Janeiro+-+RJ,+22775-055/@-22.9848827,-43.3612083,17" allowfullscreen>
+        <iframe frameborder="0" style="border:0; height:200px; width:320px;"  src="https://www.google.com/maps/embed/v1/place?key=AIzaSyCpL_11iHyHj4Bn2vgZERH8qor6VBmgT6s&q=Av.+Paisagista+Jose+Silva+de+Azevedo+Neto,+850+-+222+-+Barra+da+Tijuca,+Rio+de+Janeiro+-+RJ" allowfullscreen>
         </iframe>
         <br>
         <address>

--- a/app/en/partials/home.html
+++ b/app/en/partials/home.html
@@ -17,46 +17,46 @@
       <div class="carousel-inner">
         <div class="item active">
           <div class="row">
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.PLDD"><img src="images/back-nobg.png" alt="PLDD"></a>
               </div>
               <h4>PLDD</h4>
               <p class="col-sm-10 col-sm-offset-1">Treatment of back pain resulting from herniated discs. <a ui-sref="app.PLDD">Learn more...</a></p>
             </div>
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.EVLA"><img src="images/knee-blackNgreen.png" alt="EVLA" class=""></a>
               </div>
               <h4>EVLA</h4>
               <p class="col-sm-10 col-sm-offset-1">Treatment of varicose veins.<br><a ui-sref="app.EVLA">Learn more...</a></p>
             </div>
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.ENT"><img src="images/ENT-nobg.png" alt="ENT" class=""></a>
               </div>
-              <h4>OTOLARYNGOLOGY</h4>
+              <h4>ENT</h4>
               <p class="col-sm-10 col-sm-offset-1">Oral cavity, laryngeal, nasal, pharyngeal, and otology procedures. <a ui-sref="app.ENT">Learn more...</a></p>
             </div>
-          </div><!--/row-->
-        </div><!--/item-->
-        <div class="item">
-          <div class="row">
-            <div class="col-sm-4 col-xs-6">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.proctology"><img src="images/proctology-transparent.png" alt="Proctology" class=""></a>
               </div>
               <h4>PROCTOLOGY</h4>
               <p class="col-sm-10 col-sm-offset-1">New treatment options!<br><a ui-sref="app.proctology">Learn more...</a></p>
             </div>
-            <div class="col-sm-4 col-xs-6">
+          </div><!--/row-->
+        </div><!--/item-->
+        <div class="item">
+          <div class="row">
+            <div class="col-sm-3 col-xs-3 col-sm-offset-3 col-sm-offset-3">
               <div class="img-wrapper">
                 <a ui-sref="app.products"><img src="images/smallest-machine.png" alt="Image" class="img-responsive"></a>
               </div>
               <h4>WORLD CLASS DESIGN</h4>
               <p class="col-sm-10 col-sm-offset-1">The smallest, lightest weight, and most portable laser system of its power class.</p>
             </div>
-            <div class="col-sm-4 col-xs-6">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.about"><img src="images/neolaser-logo.png" alt="NEO V980" class="center-block img-responsive"></a>
               </div>

--- a/app/en/partials/neoV1470.html
+++ b/app/en/partials/neoV1470.html
@@ -27,9 +27,9 @@
           <h3 class="Lato"><i class="fa" ng-class="plusSignJ1 ? 'fa-minus' : 'fa-plus'"></i>&emsp;TREATMENTS</h3>
         </div>
         <ul id="treatment" class="collapse marginJ">
-          <li>Telangiectasia</li>
           <li>Vascular Lesions</li>
           <li>Endovenous Ablation</li>
+          <li>Proctology</li>
         </ul>
       </div>
     </div>
@@ -129,12 +129,13 @@
         <div id="applications" class="collapse">
           <div class="row marginJ">
             <div class="col-xs-12 col-sm-6">
-              <h4>Endovenous Treatment (EVLA)</h4>
-              <p>The neoV 1470 diode laser offers a novel wavelength with superior performance for ablation of diseased veins. In contrast to previous generations of laser therapy with deep tissue penetration, the 1,470nm wavelength is highly absorbed by water in tissue. As a result heat generation is highly localized and application is safe and precise.</p>
+              <h4><a ui-sref="app.proctology">Proctology</a></h4>
+              <p>The neoV 1470 with the special CORONA Fistula Probe is a unique product optimized for fistula-in-ano treatments. The fiber provides circular emission through a thin fused glass tip, facilitating closure and minimal collateral damage beyond the fistula wall. The procedures offer a safe and effective treatment, saving the sphincter muscle, and without any risk of long term incontinence.</p>
+              <p>The neoV 1470 with the CORONA Hemorrhoid Probe is a unique product optimized for grade 2-4 hemorrhoid treatments. The fiber has a custom designed conical glass tip facilitating easy puncture and entry into the hemorrhoidal pile. Emission is both frontal and side firing, wide and radially uniform, allowing efficient obliteration of feeding vessels. The fiber is equipped with a Tuohy-Borst luer adaptor enabling connection to a specialty cannula for easy handling and application.</p>
             </div>
             <div class="col-xs-12 col-sm-6">
-              <h4>Percutaneous Laser Disc Decompression (PLDD)</h4>
-              <p>In Orthopedic treatment of lumbar disc herniation, the neoV 1470 enables PLDD procedures. Laser energy is delivered by a fiber through a hollow needle to evaporate water and tissue content thereby reducing pressure and as a result, relieving back pain.</p>
+              <h4><a ui-sref="app.EVLA">Endovenous Treatment (EVLA)</a></h4>
+              <p>The neoV 1470 diode laser offers a novel wavelength with superior performance for ablation of diseased veins. In contrast to previous generations of laser therapy with deep tissue penetration, the 1,470nm wavelength is highly absorbed by water in tissue. As a result heat generation is highly localized and application is safe and precise.</p>
             </div>
           </div>
         </div>

--- a/app/en/partials/neoV980.html
+++ b/app/en/partials/neoV980.html
@@ -15,7 +15,7 @@
           <img src="images/neoV02.png" class="img-responsive">
         </div>
         <div class="col-xs-12 col-sm-7">
-          <p>The neoV980 is a cutting edge all purpose surgical tool for a wide scope of clinical applications. The 980nm wavelength offering almost equal absorption in water and blood, coupled with the higher power throughput of the neoV platform, enables safe and effective treatment of many conditions, from ENT and GYN Surgery, through EVLA and PLDD treatments, to Laser Assisted Lipolysis and Dermatological Vascular Lesion treatment. <a ui-sref="app.contact"><strong>Contact us for more information on this highly robust unit.</strong></a></p>
+          <p>The neoV980 is a cutting edge all purpose surgical tool for a wide scope of clinical applications. The 980nm wavelength offering almost equal absorption in water and blood, coupled with the higher power throughput of the neoV platform, enables safe and effective treatment of many conditions. <a ui-sref="app.contact"><strong>Contact us for more information on this highly robust unit.</strong></a></p>
         </div>
       </div>
     </div>
@@ -27,11 +27,8 @@
           <h3 class="Lato"><i class="fa" ng-class="plusSignJ1 ? 'fa-minus' : 'fa-plus'"></i>&emsp;TREATMENTS</h3>
         </div>
         <ul id="treatment" class="collapse marginJ">
-          <li>Gastroenterology (GI)</li>
-          <li>Gynecology</li>
-          <li>Orthopedics</li>
-          <li>Otolaryngology &ndash; Ears, Nose &amp; Throat (ENT)</li>
-          <li>Pulmonary</li>
+          <li>ENT &ndash; Ears, Nose &amp; Throat</li>
+          <li>PLDD</li>
         </ul>
       </div>
     </div>
@@ -107,7 +104,7 @@
                 <td>Portability</td>
               </tr>
               <tr>
-                <td>Indications in ENT, GYN, ORTHO, PULM/GI</td>
+                <td>Indications in ENT &amp; PLDD</td>
                 <td>Custom designed carrying suitcase</td>
                 <td>Rapid setup with surgeon presets</td>
                 <td>Standard power connection</td>
@@ -133,22 +130,12 @@
         <div id="applications" class="collapse">
           <div class="row marginJ">
             <div class="col-xs-12 col-sm-6">
-              <h4>Gastroenterology (GI)</h4>
-              <p>The use of laser energy at 980nm through flexible endoscopes in the field of Gastroenterology can assist in a wide variety of conditions. The strong coagulative power of the energy can be exploited to treat GI bleeders, to ablate and destroy lesions, including treatment of abnormal mucosa, or strictures.</p>
+              <h4>Percutaneous Laser Disc Decompression (PLDD)</h4>
+              <p>In Orthopedic treatment of lumbar disc herniation, the neoV 1470 enables PLDD procedures. Laser energy is delivered by a fiber through a hollow needle to evaporate water and tissue content thereby reducing pressure and as a result, relieving back pain.</p>
             </div>
             <div class="col-xs-12 col-sm-6">
-              <h4>Orthopedics</h4>
-              <p>In Orthopedic treatment of lumbar disc herniation, the neoV 980 enables Percutaneous Laser Disc Decompression (PLDD) procedures. Laser energy is delivered by a fiber through a hollow needle to evaporate water and tissue content thereby reducing pressure and as a result, relieving back pain.</p>
-            </div>
-          </div>
-          <div class="row marginJ">
-            <div class="col-xs-12 col-sm-6">
-              <h4>Otolaryngology (ENT)</h4>
+              <h4>ENT &ndash; Ears, nose &amp; throat</h4>
               <p>In ENT the laser is ideal for nasal surgery including polyps, cysts, and septum treatment. Oral application for tonsillectomy, glossectomy, oral lesions, and uvulopalatoplasty is recommended, as well as laryngeal, subglottic lesions, including office-based treatments. A special kit is offered for treatment of Dacryocystorhinostomy (DCR).</p>
-            </div>
-            <div class="col-xs-12 col-sm-6">
-              <h4>Pulmonary</h4>
-              <p>Whether it is Central Airway Obstruction (CAO) or lesions deeper in the bronchi, the 980nm wavelength, having strong coagulation power, can assist in debulking, coagulating and removing obstructing tumors. With use of gas cooled fibers through flexible endoscopy, surgical reach can be expanded and improved.</p>
             </div>
           </div>
         </div>

--- a/app/en/partials/proctology.html
+++ b/app/en/partials/proctology.html
@@ -181,7 +181,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTOLARYNGOLOGY</strong><br>Ears, nose, and throat</p>
+        <p><strong>ENT</strong><br>Ears, nose, and throat</p>
         </a>
       </div>
       <div class="row">

--- a/app/en/partials/treatments.html
+++ b/app/en/partials/treatments.html
@@ -53,24 +53,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsplddBox"><h4>THE NEOV</h4></div>
+                <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>CONTACT US</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsplddBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -97,24 +83,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsentBox"><h4>THE NEOV</h4></div>
+                <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>CONTACT US</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsentBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -139,24 +111,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsproctoBox"><h4>THE NEOV</h4></div>
+                <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>CONTACT US</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsproctoBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/app/en/scripts/app.js
+++ b/app/en/scripts/app.js
@@ -60,7 +60,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.neoV980', {
-    url:'neoV-980',
+    url:'our-products/neoV-980',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/neoV980.html',
@@ -70,7 +70,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.neoV1470', {
-    url:'neoV-1470',
+    url:'our-products/neoV-1470',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/neoV1470.html'
@@ -88,7 +88,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.EVLA', {
-    url:'endovascular-applications',
+    url:'treatments/endovascular-applications',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/EVLA.html',
@@ -98,7 +98,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.PLDD', {
-    url:'percutaneous-laser-disc-decompression',
+    url:'treatments/percutaneous-laser-disc-decompression',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/PLDD.html'
@@ -107,7 +107,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.proctology', {
-    url:'proctology',
+    url:'treatments/proctology',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/proctology.html'
@@ -116,7 +116,7 @@ angular.module('neoApp_en-us', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.ENT', {
-    url:'otolaryngology',
+    url:'treatments/ENT',
     views: {
       'content@': {
         templateUrl: 'app/en/partials/ENT.html'

--- a/app/en/templates/header.html
+++ b/app/en/templates/header.html
@@ -23,9 +23,9 @@
       Treatments <span class="caret"></span>
       </li>
       <ul id="treatments" class="collapse">
+        <li><a ui-sref="app.ENT">ENT</a></li>
         <li><a ui-sref="app.PLDD">PLDD</a></li>
         <li><a ui-sref="app.EVLA">EVLA</a></li>
-        <li><a ui-sref="app.ENT">Otolaryngology</a></li>
         <li><a ui-sref="app.proctology">Proctology</a></li>
       </ul>
       <li><a ui-sref="app.events">Events</a></li>
@@ -76,10 +76,10 @@
         <li class="dropdown">
           <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">TREATMENTS <span class="caret"></span></a>
           <ul class="dropdown-menu">
+            <li><a ui-sref="app.ENT">ENT</a></li>
             <li><a ui-sref="app.EVLA">ENDOVASCULAR APPLICATIONS</a></li>
             <li><a ui-sref="app.PLDD">PLDD</a></li>
             <li><a ui-sref="app.proctology">PROCTOLOGY</a></li>
-            <li><a ui-sref="app.ENT">OTOLARYNGOLOGY</a></li>
           </ul>
         </li>
       </ul>

--- a/app/pt/partials/ENT.html
+++ b/app/pt/partials/ENT.html
@@ -1,7 +1,7 @@
 <ol class="breadcrumb">
   <li class="breadcrumb-item"><a ui-sref="app">Início</a></li>
   <li class="breadcrumb-item"><a ui-sref="app.treatments">Tratamentos</a></li>
-  <li class="breadcrumb-item active">Otorrinolaringologia</li>
+  <li class="breadcrumb-item active">ENT</li>
 </ol>
 <div id="entWrapper" class="treatmentWrapper sliderYp slide-page">
   <div class="row">
@@ -9,7 +9,7 @@
       <div class="jumbotron topJ">
         <div class="container">
           <div class="row">
-            <h1 class="text-center">OTORRINO</h1>
+            <h1 class="text-center">ENT &ndash; Ouvidos, Nariz &amp; Garganta</h1>
           </div>
           <div class="row">
             <div class="col-xs-12 col-sm-5">
@@ -17,7 +17,7 @@
             </div>
             <div class="col-xs-12 col-sm-7">
               <p class="text-justify">
-                O laser NeoV pode ser utilizado como uma ferramenta de coagulação e de corte de precisão para uma variedade de aplicações cirúrgicas nos campos da otorrinolaringologia, como ...</p>
+                O laser NeoV pode ser utilizado como uma ferramenta de coagulação e de corte de precisão para uma variedade de aplicações cirúrgicas nos campos de ENT, como ...</p>
               <div id="last" class="collapse">
                 <p class="text-justify">
                   Deformação do septo, pólipos, cistos, mucoceles, amigdalectomia, LAUP, glossectomia, estapedotomia, DCR, cordectomia, epiglottectomy, cirurgia de papiloma, bem como excisão de lesões cancerosas.
@@ -177,7 +177,7 @@
                   </tr>
                   <tr>
                     <th scope="row">Vários Comprimentos de Onda</th>
-                    <td>O NeoV 980 e o NeoV 1470 são duas ferramentas altamente eficazes porém diferentes para a otorrinolaringologia, por possuirem diferentes absorção no tecido mole. Assim, ambos os sistemas cobrem uma gama de opções de interação com o tecido, desde coagulação forte e profunda à excisões micro-cirúrgicas de precisão.</td>
+                    <td>O NeoV 980 e o NeoV 1470 são duas ferramentas altamente eficazes porém diferentes para ENT, por possuirem diferentes absorção no tecido mole. Assim, ambos os sistemas cobrem uma gama de opções de interação com o tecido, desde coagulação forte e profunda à excisões micro-cirúrgicas de precisão.</td>
                   </tr>
                   <tr>
                     <th scope="row">Interação Flexível com o Tecido</th>
@@ -193,7 +193,7 @@
                   </tr>
                   <tr>
                     <th scope="row">Valor </th>
-                    <td>A plataforma NeoV oferece o melhor valor no mercado para a sua clínica de otorrinolaringologia através de um design exclusivo, qualidade, portabilidade e desempenho de alto nível.</td>
+                    <td>A plataforma NeoV oferece o melhor valor no mercado para a sua clínica de ENT através de um design exclusivo, qualidade, portabilidade e desempenho de alto nível.</td>
                   </tr>
                 </tbody>
               </table>
@@ -224,20 +224,11 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-xs-12 col-sm-6">
+            <div class="col-xs-12 col-sm-12">
               <a a type="button" ui-sref="app.treatments">
                 <div class="btn-simple">
                   <h3>
                     OUTROS TRATAMENTOS
-                  </h3>
-                </div>
-              </a>
-            </div>
-            <div class="col-xs-12 col-sm-6">
-              <a type="button" ui-sref="app.neoV1470">
-                <div class="btn-simple">
-                  <h3>
-                    MAIS SOBRE O NEOV 1470
                   </h3>
                 </div>
               </a>

--- a/app/pt/partials/EVLA.html
+++ b/app/pt/partials/EVLA.html
@@ -300,7 +300,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTORRINO</strong><br>Ouvidos, nariz e garganta</p>
+        <p><strong>ENT</strong><br>Ouvidos, nariz e garganta</p>
         </a>
       </div>
       <div class="row">

--- a/app/pt/partials/PLDD.html
+++ b/app/pt/partials/PLDD.html
@@ -234,7 +234,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTORRINO</strong><br>Ouvidos, nariz, e garganta</p>
+        <p><strong>ENT</strong><br>Ouvidos, nariz, e garganta</p>
         </a>
       </div>
       <div class="row">

--- a/app/pt/partials/contact.html
+++ b/app/pt/partials/contact.html
@@ -11,7 +11,7 @@
             Nome*
           </label>
           <div class="col-xs-12 col-sm-8">
-            <input type="text" id="firstName" name="First Name" placeholder="Your First Name" class="form-control" required="">
+            <input type="text" id="firstName" name="First Name" placeholder="Seu Nome" class="form-control" required="">
           </div>
         </div>
         <div class="form-group">
@@ -19,7 +19,7 @@
             Sobrenome*
           </label>
           <div class="col-xs-12 col-sm-8">
-            <input type="text" id="lastName" name="Last Name" placeholder="Your Last Name" class="form-control" required="">
+            <input type="text" id="lastName" name="Last Name" placeholder="Seu Sobrenome" class="form-control" required="">
           </div>
         </div>
         <div class="form-group">
@@ -35,7 +35,7 @@
             Tel.
           </label>
           <div class="col-xs-12 col-sm-8">
-            <input type="tel" id="tel" name="Phone #" placeholder="(555) 555-5555" class="form-control">
+            <input type="tel" id="tel" name="Phone #" placeholder="(xx) 99999-9999" class="form-control">
           </div>
         </div>
         <div class="form-group">
@@ -82,7 +82,7 @@
         <strong>Onde Estamos</strong>
       </p>
       <div class="iframe-container">
-        <iframe frameborder="0" style="border:0; height:200px; width:320px;"  src="https://www.google.com/maps/embed/v1/place?key=AIzaSyCpL_11iHyHj4Bn2vgZERH8qor6VBmgT6s&q=Av.+Joao+de+Cabral+de+Melo+Neto,+850+-+Barra+da+Tijuca,+Rio+de+Janeiro+-+RJ,+22775-055/@-22.9848827,-43.3612083,17" allowfullscreen>
+        <iframe frameborder="0" style="border:0; height:200px; width:320px;"  src="https://www.google.com/maps/embed/v1/place?key=AIzaSyCpL_11iHyHj4Bn2vgZERH8qor6VBmgT6s&q=Av.+Paisagista+Jose+Silva+de+Azevedo+Neto,+850+-+222+-+Barra+da+Tijuca,+Rio+de+Janeiro+-+RJ" allowfullscreen>
         </iframe>
         <br>
         <address>

--- a/app/pt/partials/home.html
+++ b/app/pt/partials/home.html
@@ -17,46 +17,46 @@
       <div class="carousel-inner">
         <div class="item active">
           <div class="row">
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.PLDD"><img src="images/back-nobg.png" alt="PLDD"></a>
               </div>
               <h4>COLUNA</h4>
-              <p class="col-sm-10 col-sm-offset-1">Tratamento para dores de coluna resultantes de hérnia de disco.<br><a ui-sref="app.PLDD"><strong>Saiba mais sobre PLDD</strong></a></p>
+              <p class="col-sm-10 col-sm-offset-1">Tratamento para dores de coluna resultantes de hérnia de disco. <a ui-sref="app.PLDD"><strong>Saiba mais sobre PLDD</strong></a></p>
             </div>
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.EVLA"><img src="images/knee-blackNgreen.png" alt="EVLA" class=""></a>
               </div>
               <h4>VASCULAR</h4>
               <p class="col-sm-10 col-sm-offset-1">Tratamento de varizes.<br><a ui-sref="app.EVLA"><strong>Saiba Mais</strong></a></p>
             </div>
-            <div class="col-sm-4 col-xs-4">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.ENT"><img src="images/ENT-nobg.png" alt="ENT" class=""></a>
               </div>
-              <h4>OTORRINO</h4>
+              <h4>ENT</h4>
               <p class="col-sm-10 col-sm-offset-1">Cavidade oral, laríngea, nasal, faríngea e procedimentos otológicos. <a ui-sref="app.ENT"><strong>Saiba Mais</strong></a></p>
             </div>
-          </div><!--/row-->
-        </div><!--/item-->
-        <div class="item">
-          <div class="row">
-            <div class="col-sm-4 col-xs-6">
+            <div class="col-sm-3 col-xs-3">
               <div class="img-wrapper">
                 <a ui-sref="app.proctology"><img src="images/proctology-transparent.png" alt="Proctology" class=""></a>
               </div>
               <h4>PROCTOLOGIA</h4>
               <p class="col-sm-10 col-sm-offset-1">Novas opções de tratamento<br><a ui-sref="app.proctology"><strong>Saiba Mais</strong></a></p>
             </div>
-            <div class="col-sm-4 col-xs-6">
+          </div><!--/row-->
+        </div><!--/item-->
+        <div class="item">
+          <div class="row">
+            <div class="col-sm-4 col-xs-4 col-sm-offset-2">
               <div class="img-wrapper">
                 <a ui-sref="app.products"><img src="images/smallest-machine.png" alt="Image" class="img-responsive"></a>
               </div>
               <h4>DESIGN DE RENOME GLOBAL</h4>
               <p class="col-sm-10 col-sm-offset-1">O menor, o mais leve e o mais portável sistema a laser de sua classe de potência.<br><a ui-sref="app.products"><strong>Saiba mais sobre o neoV laser</strong></a></p>
             </div>
-            <div class="col-sm-4 col-xs-6">
+            <div class="col-sm-4 col-xs-4">
               <div class="img-wrapper">
                 <a ui-sref="app.about"><img src="images/neolaser-logo.png" alt="NEO V980" class="center-block img-responsive"></a>
               </div>

--- a/app/pt/partials/neoV1470.html
+++ b/app/pt/partials/neoV1470.html
@@ -27,9 +27,9 @@
           <h3 class="Lato"><i class="fa" ng-class="plusSignJ1 ? 'fa-minus' : 'fa-plus'"></i>&emsp;TRATAMENTOS</h3>
         </div>
         <ul id="treatment" class="collapse marginJ">
-          <li>Telangiectasia</li>
           <li>Lesões Vasculares</li>
           <li>Ablação Endovenosa</li>
+          <li>Proctologia</li>
         </ul>
       </div>
     </div>
@@ -129,12 +129,13 @@
         <div id="applications" class="collapse">
           <div class="row marginJ">
             <div class="col-xs-12 col-sm-6">
-              <h4>Tratamento Endovenoso (EVLA)</h4>
-              <p>O diodo laser neoV 1470 oferece um comprimento de onda singular com desempenho superior para ablação de veias doentes. Em contraste com as gerações anteriores de terapia a laser com penetração profunda do tecido, o comprimento de onda 1470nm é altamente absorvido pela água no tecido. Como resultado, a produção de calor é altamente localizada e a aplicação é segura e precisa.</p>
+              <h4><a ui-sref="app.proctology">Proctologia</a></h4>
+              <p>O neoV 1470, com a sonda CORONA para fístulas, é um produto único otimizado para tratamentos de fístula anal. A fibra proporciona emissão circular através de uma ponta fina de vidro fundido, facilitando o fechamento e danos colaterais mínimos para além da parede da fístula. Os procedimentos oferecem um tratamento seguro e eficaz, salvando o músculo esfíncter, e sem qualquer risco de incontinência de longo prazo.</p>
+              <p>O neoV 1470, com a sonda CORONA para hemorróidas, é um produto exclusivo otimizado para tratamentos de hemorroidas graus 2-4. A fibra tem uma ponta de vidro cônica projetada facilitando fácil punção e entrada na pilha hemorrhoidal. A emissão é frontal e lateral, ampla e radialmente uniforme, permitindo a obliteração eficiente dos vasos de alimentação. A fibra é equipada com um adaptador Touhy-Borst permitindo a conexão a uma cânula de especialidade para fácil manuseio e aplicação.</p>
             </div>
             <div class="col-xs-12 col-sm-6">
-              <h4>Descompressão Percutânea de Disco a Laser (PLDD)</h4>
-              <p>No tratamento ortopédico de hérnia de disco, o neoV 1470 permite procedimentos PLDD. A energia do laser é emitida por uma fibra através de uma agulha oca, que evapora o conteúdo de água no tecido reduzindo a pressão e, como resultado, aliviando a dor nas costas.</p>
+              <h4><a ui-sref="app.EVLA">Tratamento Endovenoso (EVLA)</a></h4>
+              <p>O diodo laser neoV 1470 oferece um comprimento de onda singular com desempenho superior para ablação de veias doentes. Em contraste com as gerações anteriores de terapia a laser com penetração profunda do tecido, o comprimento de onda 1470nm é altamente absorvido pela água no tecido. Como resultado, a produção de calor é altamente localizada e a aplicação é segura e precisa.</p>
             </div>
           </div>
         </div>

--- a/app/pt/partials/neoV980.html
+++ b/app/pt/partials/neoV980.html
@@ -15,7 +15,7 @@
           <img src="images/neoV02.png" class="img-responsive">
         </div>
         <div class="col-xs-12 col-sm-7">
-          <p class="text-justify">O neoV 980 é uma ferramenta cirúrgica de ponta, ilimitada, destinada a uma ampla gama de aplicações clínicas. O comprimento de onda de 980nm, com quase igual absorção de água e sangue, juntamente com a maior taxa de transferência de energia da plataforma NeoV, permite tratamentos seguros e eficazes de muitas condições, desde otorrinolaringologia à aplicações endovasculares e tratamentos de PLDD, até lipólise assistida por laser e tratamento dermatológico de lesão vascular. <a ui-sref="app.contact"><strong>Contacte-nos para mais informações sobre esta unidade altamente robusta.</strong></a></p>
+          <p class="text-justify">O neoV 980 é uma ferramenta cirúrgica de ponta, ilimitada, destinada a uma ampla gama de aplicações clínicas. O comprimento de onda de 980nm, com quase igual absorção de água e sangue, juntamente com a maior taxa de transferência de energia da plataforma NeoV, permite tratamentos seguros e eficazes de muitas condições. <a ui-sref="app.contact"><strong>Contacte-nos para mais informações sobre esta unidade altamente robusta.</strong></a></p>
         </div>
       </div>
     </div>
@@ -27,11 +27,8 @@
           <h3 class="Lato"><i class="fa" ng-class="plusSignJ1 ? 'fa-minus' : 'fa-plus'"></i>&emsp;TRATAMENTOS</h3>
         </div>
         <ul id="treatment" class="collapse marginJ">
-          <li>Gastroenterologia</li>
-          <li>Ginecologia</li>
-          <li>Ortopedia</li>
-          <li>Otorrinolaringologia &ndash; Ouvidos, Nariz &amp; Garganta</li>
-          <li>Pulmonar</li>
+          <li>ENT &ndash; Ouvidos, Nariz &amp; Garganta</li>
+          <li>PLDD</li>
         </ul>
       </div>
     </div>
@@ -107,7 +104,7 @@
                 <td>Portabilidade</td>
               </tr>
               <tr>
-                <td>Indicações em Otorrino, Ginecologia, Ortopedia, Pulmonar e Gastro</td>
+                <td>Indicações em ENT &amp; PLDD</td>
                 <td>Maleta de transporte personalizada</td>
                 <td>Configuração rápida com predefinições</td>
                 <td>Tomada padrão</td>
@@ -133,22 +130,12 @@
         <div id="applications" class="collapse">
           <div class="row marginJ">
             <div class="col-xs-12 col-sm-6">
-              <h4>Gastroenterologia (GI)</h4>
-              <p>A utilização de energia laser a 980 nm através de endoscópios flexíveis no campo de Gastroenterologia pode auxiliar numa ampla variedade de condições. O forte poder de coagulação da energia pode ser explorado no tratamento de sangradores GI, na ablação e neutralização de lesões, incluindo o tratamento da mucosa anormal, ou estenoses.</p>
+              <h4>ENT</h4>
+              <p>Em ENT o laser é ideal para a cirurgia nasal incluindo pólipos, cistos e tratamento de septo. Aplicação oral para amigdalectomia, glossectomia, lesões orais, e uvulopalatoplastia é recomendada, bem como para lesões laríngeas, subglóticas, incluindo tratamentos em consultório. Um kit especial é oferecido para o tratamento de dacriocistorrinostomia (DCR).</p>
             </div>
             <div class="col-xs-12 col-sm-6">
-              <h4>Ortopedia</h4>
-              <p>No tratamento ortopédico de hérnia de disco lombar, o neoV 980 permite procedimentos de PLDD. A energia do laser é emitida por uma fibra através de uma agulha oca para evaporar água e conteúdos teciduais, reduzindo a pressão e, como resultado, aliviando a dor nas costas.</p>
-            </div>
-          </div>
-          <div class="row marginJ">
-            <div class="col-xs-12 col-sm-6">
-              <h4>Otorrinolaringologia</h4>
-              <p>Em otorrino o laser é ideal para a cirurgia nasal incluindo pólipos, cistos e tratamento de septo. Aplicação oral para amigdalectomia, glossectomia, lesões orais, e uvulopalatoplastia é recomendada, bem como para lesões laríngeas, subglóticas, incluindo tratamentos em consultório. Um kit especial é oferecido para o tratamento de dacriocistorrinostomia (DCR).</p>
-            </div>
-            <div class="col-xs-12 col-sm-6">
-              <h4>Pulmonar</h4>
-              <p>Quer se trate de obstrução das vias aéreas superiores ou lesões mais profundas nos brônquios, o comprimento de onda 980nm, com forte poder de coagulação, pode auxiliar na diminuição de volume, coagulação e remoção de tumores obstrutores. Com o uso de fibras arrefecidas por gás através de endoscopia flexível, o alcance cirúrgico pode ser ampliado e melhorado.</p>
+              <h4>Descompressão Percutânea de Disco a Laser (PLDD)</h4>
+              <p>No tratamento ortopédico de hérnia de disco, o neoV 1470 permite procedimentos PLDD. A energia do laser é emitida por uma fibra através de uma agulha oca, que evapora o conteúdo de água no tecido reduzindo a pressão e, como resultado, aliviando a dor nas costas.</p>
             </div>
           </div>
         </div>

--- a/app/pt/partials/proctology.html
+++ b/app/pt/partials/proctology.html
@@ -182,7 +182,7 @@
         <div class="img-wrapper">
           <img src="images/ENT-nobg.png">
         </div>
-        <p><strong>OTORRINO</strong><br>Ouvidos, nariz e garganta</p>
+        <p><strong>ENT</strong><br>Ouvidos, nariz e garganta</p>
         </a>
       </div>
       <div class="row">

--- a/app/pt/partials/treatments.html
+++ b/app/pt/partials/treatments.html
@@ -53,24 +53,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsplddBox"><h4>O NEOV</h4></div>
+                <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>FALE CONOSCO</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsplddBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -84,7 +70,7 @@
             <div class="img-wrapper">
               <img src="images/ENT-nobg.png"/>
             </div>
-            <h2>OTORRINOLARINGOLOGIA</h2>
+            <h2>ENT</h2>
           </div>
           <div class="row collapse" id="moreOnENT">
             <div class="row">
@@ -97,24 +83,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsentBox"><h4>O NEOV</h4></div>
+                <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>FALE CONOSCO</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsentBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -139,24 +111,10 @@
             </div>
             <div class="row">
               <div class="col-xs-12 col-sm-6">
-                <div role="button" class="collapsed btn-simple" data-toggle="collapse" href="#neoVsproctoBox"><h4>O NEOV</h4></div>
+                <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
               </div>
               <div class="col-xs-12 col-sm-6">
                 <a ui-sref="app.contact"><div class="btn-simple" role="button"><h4>FALE CONOSCO</h4></div></a>
-              </div>
-            </div>
-            <div class="row collapse" id="neoVsproctoBox">
-              <div class="col-xs-12 col-sm-6">
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV980"><div class="btn-simple" role="button"><h4>NEOV 980</h4></div></a>
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-xs-12">
-                    <a ui-sref="app.neoV1470"><div class="btn-simple" role="button"><h4>NEOV 1470</h4></div></a>
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/app/pt/scripts/app.js
+++ b/app/pt/scripts/app.js
@@ -60,7 +60,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.neoV980', {
-    url:'neoV-980',
+    url:'nossos-produtos/neoV-980',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/neoV980.html',
@@ -70,7 +70,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.neoV1470', {
-    url:'neoV-1470',
+    url:'nossos-produtos/neoV-1470',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/neoV1470.html'
@@ -88,7 +88,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.EVLA', {
-    url:'aplicacoes-endovasculares',
+    url:'tratamentos/aplicacoes-endovasculares',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/EVLA.html',
@@ -98,7 +98,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.PLDD', {
-    url:'PLDD',
+    url:'tratamentos/PLDD',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/PLDD.html'
@@ -107,7 +107,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.proctology', {
-    url:'proctologia',
+    url:'tratamentos/proctologia',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/proctology.html'
@@ -116,7 +116,7 @@ angular.module('neoApp_pt-br', ['ui.router', 'angular.backtop'])
   })
 
   .state('app.ENT', {
-    url:'otorrinolaringologia',
+    url:'tratamentos/ENT',
     views: {
       'content@': {
         templateUrl: 'app/pt/partials/ENT.html'

--- a/app/pt/templates/header.html
+++ b/app/pt/templates/header.html
@@ -23,9 +23,9 @@
       Tratamentos <span class="caret"></span>
       </li>
       <ul id="treatments" class="collapse">
+        <li><a ui-sref="app.ENT">ENT</a></li>
         <li><a ui-sref="app.PLDD">PLDD</a></li>
         <li><a ui-sref="app.EVLA">Vascular</a></li>
-        <li><a ui-sref="app.ENT">Otorrinolaringologia</a></li>
         <li><a ui-sref="app.proctology">Proctologia</a></li>
       </ul>
       <li><a ui-sref="app.events">Eventos</a></li>
@@ -76,10 +76,10 @@
           <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">TRATAMENTOS <span class="caret"></span></a>
             <ul class="dropdown-menu">
+              <li><a ui-sref="app.ENT">ENT</a></li>
               <li><a ui-sref="app.EVLA">APLICAÇÕES ENDOVASCULARES</a></li>
               <li><a ui-sref="app.PLDD">PLDD</a></li>
               <li><a ui-sref="app.proctology">PROCTOLOGIA</a></li>
-              <li><a ui-sref="app.ENT">OTORRINOLARINGOLOGIA</a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
* Replace the word "Otolaryngology" for "ENT" in all pages
* Bring proctology thumbnail to first slide on the home page
* Erase "pulmonary", "gyn" and any other types of treatment other than PLDD, ENT, EVLA & proctology from all pages
* neov 980 - ENT & PLDD
* neov 1470 - EVLA & proctology

**Non-requested Updates**
* "sub-routes" now include `treatments/` and `our-products/`
* fixed map on "contact us" page